### PR TITLE
quick merge of small e-mail security change

### DIFF
--- a/app.js
+++ b/app.js
@@ -125,10 +125,12 @@ app.locals({
   md: require('marked'),
   alcohol: require('./lib/alcohol').stringify,
   jumble: function(str){
-    var ere = /(.*?)@/;
+    var ere = /(.*?)@/, ret, len;
     if (ere.test(str)){
-      res = ere.exec(str);
-      return res[1];
+      ret = ere.exec(str)[1];
+      len = ret.length;
+      ret = ret.substr(0,3) + "***" + ret.charAt(len - 1);
+      return ret;
     }
     return "INVILID E-MAIL";
   }

--- a/app.js
+++ b/app.js
@@ -129,7 +129,7 @@ app.locals({
     if (ere.test(str)){
       ret = ere.exec(str)[1];
       len = ret.length;
-      ret = ret.substr(0,3) + "***" + ret.charAt(len - 1);
+      ret = ret.substr(0,3) + "***" + ret.charAt(len - 1) + str.substr(len);
       return ret;
     }
     return "INVILID E-MAIL";

--- a/app.js
+++ b/app.js
@@ -123,7 +123,15 @@ app.configure('production', function(){
 app.locals({
   messages: require('./lib/bootstrap2-messages'),
   md: require('marked'),
-  alcohol: require('./lib/alcohol').stringify
+  alcohol: require('./lib/alcohol').stringify,
+  jumble: function(str){
+    var ere = /(.*?)@/;
+    if (ere.test(str)){
+      res = ere.exec(str);
+      return res[1];
+    }
+    return "INVILID E-MAIL";
+  }
 });
 
 

--- a/views/event.jade
+++ b/views/event.jade
@@ -65,8 +65,8 @@ block content
         tbody
           each attendee in att_guests
             tr
-              td= attendee.email
               if user && (user.is_admin || org.admins.indexOf(user.id) >= 0)
+                td= attendee.email
                 td
                   p.gtid= attendee.gt_id
                 td 
@@ -76,6 +76,8 @@ block content
                     input(type='hidden', name='guest', value=attendee.id)
                     input(type='hidden', name='_type', value='unguest')
                     input(type='submit', value='X').btn
+              else
+                td= jumble(attendee.email)
 
 
            

--- a/views/kiosk.jade
+++ b/views/kiosk.jade
@@ -61,7 +61,7 @@ block content
         tbody
           each attendee in att_guests
             tr
-              td= attendee.email
+              td= jumble(attendee.email)
 
   script(type='text/javascript')
       function validate(){


### PR DESCRIPTION
This change obfuscate e-mails on events (and kiosk) pages so that they appear
to be only the first 3 characters of the e-mail and then the last character before the "@"
