### PR TITLE
better password recovery and temporary fix to bootstrap messages

### DIFF
--- a/app.js
+++ b/app.js
@@ -34,7 +34,8 @@ everyauth.password
         return {
             next: req.query.next,
             req: req,
-            user: req.user
+            user: req.user,
+            messages: require("./lib/bootstrap2-messages")
         };
     })
     .respondToLoginSucceed(auth.respondToLoginSucceed)
@@ -42,7 +43,8 @@ everyauth.password
         return {
             next: req.query.next,
             req: req,
-            user: req.user
+            user: req.user,
+            messages: require("./lib/bootstrap2-messages")
         };
     })
     .respondToRegistrationSucceed(auth.respondToRegistrationSucceed)
@@ -121,10 +123,7 @@ app.configure('production', function(){
 
 //local variables to the app
 app.locals({
-  messages: function(req,res){
-    console.log("IM RUNNING NOW!");
-    return require('./lib/bootstrap2-messages')(req,res);
-  },
+  messages: require("./lib/bootstrap2-messages"),
   md: require('marked'),
   alcohol: require('./lib/alcohol').stringify,
   jumble: function(str){

--- a/app.js
+++ b/app.js
@@ -121,7 +121,10 @@ app.configure('production', function(){
 
 //local variables to the app
 app.locals({
-  messages: require('./lib/bootstrap2-messages'),
+  messages: function(req,res){
+    console.log("IM RUNNING NOW!");
+    return require('./lib/bootstrap2-messages')(req,res);
+  },
   md: require('marked'),
   alcohol: require('./lib/alcohol').stringify
 });

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -169,11 +169,11 @@ exports.respondToRegistrationSucceed = function(res, user, data) {
 };
 
 exports.resetPassword = function(user, password, cb) {
-    bcrypt.gen_salt(function(err, salt) {
+    bcrypt.genSalt(function(err, salt) {
         if (err) {
           return cb(err);
         }
-        bcrypt.encrypt(password, salt, function(err, hash) {
+        bcrypt.hash(password, salt, function(err, hash) {
             if (err) {
               return cb(err);
             }

--- a/lib/bootstrap2-messages.js
+++ b/lib/bootstrap2-messages.js
@@ -19,6 +19,7 @@ module.exports = function(req, res) {
       buf.push("</div>");
     }
     buf.push("</div>");
+    req.session.messages = [];
     return buf.join('\n');
   };
 };

--- a/lib/bootstrap2-messages.js
+++ b/lib/bootstrap2-messages.js
@@ -2,10 +2,11 @@
 //NOTE: this is copied from express-messages-bootstrap, with the classes changes to support bootstrap2.0 -- JR, 02/18/12
 module.exports = function(req, res) {
   return function() {
+    console.log("I'm also running!");
     var buf, i, j, len, messages, msg, msgs, type, types, _ref;
     buf = [];
-    messages = req.flash();
-    types = Object.keys(messages);
+    messages = req.session.messages;
+    types = messages[0] || "None";
     len = types.length;
     if (!len) {
       return '';

--- a/lib/bootstrap2-messages.js
+++ b/lib/bootstrap2-messages.js
@@ -2,28 +2,21 @@
 //NOTE: this is copied from express-messages-bootstrap, with the classes changes to support bootstrap2.0 -- JR, 02/18/12
 module.exports = function(req, res) {
   return function() {
-    console.log("I'm also running!");
     var buf, i, j, len, messages, msg, msgs, type, types, _ref;
     buf = [];
-    messages = req.session.messages;
+    messages = req.session.messages || [];
     types = messages[0] || "None";
-    len = types.length;
-    if (!len) {
+    if (types === "None") {
       return '';
     }
     buf.push('<div id="messages">');
-    for (i = 0; (0 <= len ? i < len : i > len); (0 <= len ? i += 1 : i -= 1)) {
-      type = types[i];
-      msgs = messages[type];
-      if (msgs != null) {
-        buf.push("<div class=\"alert alert-" + type + "\" data-alert=\"alert\">");
-        buf.push("<a class=\"close\" href=\"#\">×</a>");
-        for (j = 0, _ref = msgs.length; (0 <= _ref ? j < _ref : j > _ref); (0 <= _ref ? j += 1 : j -= 1)) {
-          msg = msgs[j];
-          buf.push("<p>" + msg + "</p>");
-        }
-        buf.push("</div>");
-      }
+    type = types;
+    msgs = messages[1];
+    if (msgs != null) {
+      buf.push("<div class=\"alert alert-" + type + "\" data-alert=\"alert\">");
+      buf.push("<a class=\"close\" href=\"#\">×</a>");
+      buf.push("<p>" + msgs + "</p>");
+      buf.push("</div>");
     }
     buf.push("</div>");
     return buf.join('\n');

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -1,0 +1,14 @@
+/*
+ * a session-based messages storage system, made to replace
+ * express--messages-bootstrap because they are broken and 
+ * sort-of maybe making something that is a little like a 
+ * transition into express 3.0
+ *
+ * author: theDekel
+ */
+
+exports.middleware = function(req, res, next){
+  req.flash = function(type, message){
+
+  };
+};

--- a/lib/models.js
+++ b/lib/models.js
@@ -14,6 +14,16 @@ var Guest = new Schema({
     }
 });
 
+var Recovery = new Schema({
+    account: {
+      type:ObjectId,
+      ref: 'User'
+    },
+    expires: {
+      type:Date,
+      required: true
+    }
+});
 
 var User = new Schema({
     name: {
@@ -129,4 +139,5 @@ module.exports = {
     Place: mongoose.model('Place', Place),
     Part: mongoose.model('Part', Participation),
     Guest: mongoose.model('Guest', Guest),
+    Recovery: mongoose.model('Recovery', Recovery)
 };

--- a/lib/models.js
+++ b/lib/models.js
@@ -22,6 +22,10 @@ var Recovery = new Schema({
     expires: {
       type:Date,
       required: true
+    },
+    secret: {
+      type: String,
+      required: true
     }
 });
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "bcrypt": ">=0.7",
     "async": "0.1.x",
     "less": "1.x",
-    "express-messages-bootstrap": "git://github.com/JasonGiedymin/express-messages-bootstrap.git#v1.0rc-expressv3",
+    "express-messages-bootstrap": "0.1.x",
     "connect-mongodb": "1.1.x",
     "coffee-script": "1.3.x",
     "mailer": "0.6.x"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "bcrypt": ">=0.7",
     "async": "0.1.x",
     "less": "1.x",
-    "express-messages-bootstrap": "0.1.x",
+    "express-messages-bootstrap": "git://github.com/JasonGiedymin/express-messages-bootstrap.git#v1.0rc-expressv3",
     "connect-mongodb": "1.1.x",
     "coffee-script": "1.3.x",
     "mailer": "0.6.x"

--- a/routes/events.js
+++ b/routes/events.js
@@ -53,7 +53,7 @@ exports.post = function(req, res, next) {
         return next(err);
       }
       //flash success notification and redirect to GET handler
-      req.session.messages=['success'+'Event created: '+ req.body.title];
+      req.session.messages=['success','Event created: '+ req.body.title];
       res.redirect('/events/' + event._id);
     }
   );
@@ -94,7 +94,7 @@ exports.delete = function(req, res, next) {
         return next(err);
       }
       //flash message and redirect
-      req.session.messages = ['success'+ 'Event deleted: '+ event.title];
+      req.session.messages = ['success', 'Event deleted: '+ event.title];
       res.redirect('/events/');
     }
   );

--- a/routes/events.js
+++ b/routes/events.js
@@ -53,7 +53,7 @@ exports.post = function(req, res, next) {
         return next(err);
       }
       //flash success notification and redirect to GET handler
-      //req.flash('success', 'Event created: %s', req.body.title);
+      req.session.messages=['success'+'Event created: '+ req.body.title];
       res.redirect('/events/' + event._id);
     }
   );
@@ -94,7 +94,7 @@ exports.delete = function(req, res, next) {
         return next(err);
       }
       //flash message and redirect
-      //req.flash('success', 'Event deleted: %s', event.title);
+      req.session.messages = ['success'+ 'Event deleted: '+ event.title];
       res.redirect('/events/');
     }
   );

--- a/routes/orgs.js
+++ b/routes/orgs.js
@@ -94,7 +94,7 @@ exports.post = function(req, res, next) {
       return next(err);
     }
     //show a "success" message on the next page
-    req.session.messages=['success'+ 'Org created: '+ req.body.name];
+    req.session.messages=['success', 'Org created: '+ req.body.name];
     //redirect to the org's new page
     res.redirect('/orgs/' + req.body.slug);
   });
@@ -177,7 +177,7 @@ exports.delete = function(req, res, next) {
       return next(err);
     }
     //flash success message on the next page
-    req.session.messages=['success'+ 'Org deleted: '+ org.name];
+    req.session.messages=['success', 'Org deleted: '+ org.name];
     //redirect to the orgs-list page
     res.redirect('/orgs');
   });

--- a/routes/orgs.js
+++ b/routes/orgs.js
@@ -94,7 +94,7 @@ exports.post = function(req, res, next) {
       return next(err);
     }
     //show a "success" message on the next page
-    //req.flash('success', 'Org created: %s', req.body.name);
+    req.session.messages=['success'+ 'Org created: '+ req.body.name];
     //redirect to the org's new page
     res.redirect('/orgs/' + req.body.slug);
   });
@@ -177,7 +177,7 @@ exports.delete = function(req, res, next) {
       return next(err);
     }
     //flash success message on the next page
-    //req.flash('success', 'Org deleted: %s', org.name);
+    req.session.messages=['success'+ 'Org deleted: '+ org.name];
     //redirect to the orgs-list page
     res.redirect('/orgs');
   });

--- a/routes/users.js
+++ b/routes/users.js
@@ -14,7 +14,7 @@ exports.recover_post = function(req, res, next) {
     }
 
     if (!user){
-      //req.flash('error', "Couldn't find a user with that email");
+      req.session.messages=['error', "Couldn't find a user with that email"];
       return res.render('recover',{req:req});
     }
     var reset_url = 'http://' + conf.domain + '/recover/' + user.id;
@@ -30,7 +30,7 @@ exports.recover_post = function(req, res, next) {
       }
     });
 
-    //res.flash('info', 'Check your email to reset your password');
+    res.session.messages=['info'+ 'Check your email to reset your password'];
     res.render('recover', {req:req});
   });
 };
@@ -53,7 +53,7 @@ exports.reset_password_post = function(req, res, next) {
         return next(err);
       }
 
-      //req.flash('info', 'Password reset successfully');
+      req.session.mesasges=['info'+ 'Password reset successfully'];
       res.redirect('/login');
     });
   });

--- a/routes/users.js
+++ b/routes/users.js
@@ -30,7 +30,7 @@ exports.recover_post = function(req, res, next) {
       }
     });
 
-    res.session.messages=['info'+ 'Check your email to reset your password'];
+    req.session.messages=['info', 'Check your email to reset your password'];
     res.render('recover', {req:req});
   });
 };
@@ -53,7 +53,7 @@ exports.reset_password_post = function(req, res, next) {
         return next(err);
       }
 
-      req.session.mesasges=['info'+ 'Password reset successfully'];
+      req.session.mesasges=['info', 'Password reset successfully'];
       res.redirect('/login');
     });
   });

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -52,6 +52,7 @@ html
                       li.collapse-show
                           a(href='/logout') Logout
     #content.container
+      != messages(req)()
       block content
 
     script(type='text/javascript', src='/javascripts/bootstrap.min.js')

--- a/views/reset-password.jade
+++ b/views/reset-password.jade
@@ -12,6 +12,7 @@ block content
 
     form(action=req.url, method='POST')
       input(type='hidden', name='_csrf', value=req.session._csrf)
+      input(type='hidden', name='s', value=secret)
       .clearfix
         label(for='password') New Password:
         .input


### PR DESCRIPTION
This update replaces the current system of recovering passwords by only knowing the user-id with
a process where the user requests a recovery-email which include a link with both the objectId for a
unique Recovery object (see models.js) and a randomly generated secret key. by going to 
`/recover/[Recovery ObjectId]?s=[secret key]` the password can be reset. 

The Recovery object also contains an `expires` field which contains the time-of-creation + 1 hour. This
effectively makes recovery links only effective for 1 hour.

The update also includes a temporary fix to the issue with bootstrap messages not working with 
express3 (the official library is working on it, but only started recently). The quick fix gets rid of the ability
to have multiple messages of different types and only allows at most one message. Once the official
library gets it together this will be updated, alternatively, I'll write a replacement middleware for this.
